### PR TITLE
[5.x] Add the $CRONTAB_SETTINGS variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ FROM shinsenter/php:latest
 ENV ENABLE_CRONTAB=1
 
 # create crontab entry via RUN instruction
-RUN echo '* * * * * echo Hello world!' >> /etc/crontab.d/sample1;
+RUN echo '* * * * * echo "echo This line will run every minute!" | tee /tmp/cron-every-minute.txt' >> /etc/crontab.d/sample1;
 
 # or copy crontab entries via ADD instruction
 ADD ./sample2 /etc/crontab.d/
@@ -382,6 +382,20 @@ The format of a crontab entry is as follows:
 # |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
 # |  |  |  |  |
 # *  *  *  *  *  command to be executed
+```
+
+You can also easily set up cron jobs through the `$CRONTAB_SETTINGS` environment variable in the `docker-compose.yml` file.
+When the container starts, these settings are loaded into crontab, giving you more flexibility to change them later.
+
+```yml
+services:
+  web:
+    image: shinsenter/php:8.3-fpm-nginx
+    environment:
+      ENABLE_CRONTAB: "1"
+      CRONTAB_SETTINGS: |
+        0 0 * * * echo "Hello new day!" | tee /tmp/cron-daily.txt
+        * * * * * echo "This line will run every minute!" | tee /tmp/cron-every-minute.txt
 ```
 
 For more information on environment variables for cron jobs, refer to the [Other System Settings](#other-system-settings) section below.
@@ -427,6 +441,7 @@ These Docker images include additional environment variables for fine-tuning con
 | `CRONTAB_HOME`                     | `$APP_PATH`      | Specifies the `$HOME` directory for cron jobs.                                                                                        | `/path/for/crontab` |
 | `CRONTAB_MAILTO`                   | Not set          | Email address to which cron job logs are sent.                                                                                        | `admin@example.com` |
 | `CRONTAB_PATH`                     | `$PATH`          | Sets the directory paths for executing cron jobs.                                                                                     | `/path/for/crontab/bin` |
+| `CRONTAB_SETTINGS`                 | Not set          | Allows you to configure cron jobs directly in the docker-compose.yml file, making it easy to manage and update scheduled tasks within your Docker container. | `0 0 * * * echo "Hello new day!"` |
 | `CRONTAB_SHELL`                    | `/bin/sh`        | Sets the default shell for cron jobs.                                                                                                 | `/bin/bash` |
 | `CRONTAB_TZ`                       | `$TZ`            | Sets the default timezone for cron jobs. [Full list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).                   | `Asia/Tokyo` |
 | `ENABLE_TUNING_FPM`                | Not enabled      | Enables auto-tuning of PM control settings when set to `1`.                                                                           | 0 |

--- a/src/php/base-os.md
+++ b/src/php/base-os.md
@@ -161,7 +161,7 @@ FROM shinsenter/php:latest
 ENV ENABLE_CRONTAB=1
 
 # create crontab entry via RUN instruction
-RUN echo '* * * * * echo Hello world!' >> /etc/crontab.d/sample1;
+RUN echo '* * * * * echo "echo This line will run every minute!" | tee /tmp/cron-every-minute.txt' >> /etc/crontab.d/sample1;
 
 # or copy crontab entries via ADD instruction
 ADD ./sample2 /etc/crontab.d/
@@ -178,6 +178,20 @@ The format of a crontab entry is as follows:
 # |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
 # |  |  |  |  |
 # *  *  *  *  *  command to be executed
+```
+
+You can also easily set up cron jobs through the `$CRONTAB_SETTINGS` environment variable in the `docker-compose.yml` file.
+When the container starts, these settings are loaded into crontab, giving you more flexibility to change them later.
+
+```yml
+services:
+  web:
+    image: shinsenter/php:8.3-fpm-nginx
+    environment:
+      ENABLE_CRONTAB: "1"
+      CRONTAB_SETTINGS: |
+        0 0 * * * echo "Hello new day!" | tee /tmp/cron-daily.txt
+        * * * * * echo "This line will run every minute!" | tee /tmp/cron-every-minute.txt
 ```
 
 For more information on environment variables for cron jobs, refer to the [Other System Settings](#other-system-settings) section below.
@@ -220,6 +234,7 @@ These Docker images include additional environment variables for fine-tuning con
 | `CRONTAB_HOME`                     | `$APP_PATH`      | Specifies the `$HOME` directory for cron jobs.                                                                                        | `/path/for/crontab` |
 | `CRONTAB_MAILTO`                   | Not set          | Email address to which cron job logs are sent.                                                                                        | `admin@example.com` |
 | `CRONTAB_PATH`                     | `$PATH`          | Sets the directory paths for executing cron jobs.                                                                                     | `/path/for/crontab/bin` |
+| `CRONTAB_SETTINGS`                 | Not set          | Allows you to configure cron jobs directly in the docker-compose.yml file, making it easy to manage and update scheduled tasks within your Docker container. | `0 0 * * * echo "Hello new day!"` |
 | `CRONTAB_SHELL`                    | `/bin/sh`        | Sets the default shell for cron jobs.                                                                                                 | `/bin/bash` |
 | `CRONTAB_TZ`                       | `$TZ`            | Sets the default timezone for cron jobs. [Full list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).                   | `Asia/Tokyo` |
 

--- a/src/php/common/os-crontab.dockerfile
+++ b/src/php/common/os-crontab.dockerfile
@@ -11,13 +11,12 @@ RUN <<'EOF'
 echo 'Configure base crontab'
 set -e
 
+env-default CRONTAB_SHELL  '/bin/sh'
+env-default CRONTAB_MAILTO '$APP_ADMIN'
+
 if ! has-cmd crond; then
     pkg-add cron
     ln -nsf $(command -v cron) /usr/sbin/crond
-fi
-
-if ! has-s6; then
-    sed -i 's|^exec |\nif ! has-s6 \&\& has-cmd crond \&\& is-true $ENABLE_CRONTAB; then with-env crond $CRONTAB_OPTIONS; fi\n\nexec |' $DOCKER_ENTRYPOINT
 fi
 
 if has-cmd s6-service; then

--- a/src/php/common/rootfs/etc/cont-init.d/50-crontabs
+++ b/src/php/common/rootfs/etc/cont-init.d/50-crontabs
@@ -28,8 +28,8 @@ cat <<CRONTAB >$CRONTAB
 CRON_TZ=${CRONTAB_TZ:-${TZ:-UTC}}
 HOME=${CRONTAB_HOME:-$(app-path)}
 PATH=${CRONTAB_PATH:-$PATH}
-SHELL=${CRONTAB_SHELL:-/bin/sh}
-MAILTO="${CRONTAB_MAILTO:-$APP_ADMIN}"
+$(if [ ! -z "$CRONTAB_SHELL" ];  then echo "SHELL=${CRONTAB_SHELL}"; fi)
+$(if [ ! -z "$CRONTAB_MAILTO" ]; then echo "MAILTO=${CRONTAB_MAILTO}"; fi)
 
 # Job definition:
 # .---------------- minute (0 - 59)
@@ -39,6 +39,8 @@ MAILTO="${CRONTAB_MAILTO:-$APP_ADMIN}"
 # |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
 # |  |  |  |  |
 # *  *  *  *  *  command to be executed
+${CRONTAB_SETTINGS}
+
 $(if [ -d "$CRONTAB_DIR" ]; then
     for script in $(find "$CRONTAB_DIR" -type f | sort -dbfi); do
         echo -e "\n# $script"; cat "$script"
@@ -47,5 +49,11 @@ fi)
 
 CRONTAB
 
+if ! has-s6 && has-cmd crond; then
+    export APP_PATH="$(app-path)"
+    export APP_ROOT="$(app-root)"
+    cd $APP_PATH && with-env crond $CRONTAB_OPTIONS;
+fi
+
 chmod 0600 $CRONTAB
-debug-echo -i "Cron is running as $APP_USER. Config: $CRONTAB"
+debug-echo -i "Cron is running as $APP_USER.\n\n### Config:\n$(crontab -u $APP_USER -l 2>/dev/null)"


### PR DESCRIPTION
You can also easily set up cron jobs through the `$CRONTAB_SETTINGS` environment variable in the `docker-compose.yml` file.
When the container starts, these settings are loaded into crontab, giving you more flexibility to change them later.

```yml
services:
  web:
    image: shinsenter/php:8.3-fpm-nginx
    environment:
      ENABLE_CRONTAB: "1"
      CRONTAB_SETTINGS: |
        0 0 * * * echo "Hello new day!" | tee /tmp/cron-daily.txt
        * * * * * echo "This line will run every minute!" | tee /tmp/cron-every-minute.txt
```