### PR TITLE
Revert "[5.x] FrankenPHP does not support PHP 8.4 (#165)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Examples:
 
 > <sup>(*)</sup>: The latest stable version.<br>
 > <sup>(1)</sup>: PHP with RoadRunner server. The `roadrunner` variant supports PHP >= 8.0.<br>
-> <sup>(2)</sup>: FrankenPHP is still in BETA. The `frankenphp` variant supports PHP 8.2 and 8.3.<br>
+> <sup>(2)</sup>: FrankenPHP is still in BETA. The `frankenphp` variant supports PHP >= 8.2.<br>
 > <sup>(3)</sup>: PHP with Nginx Unit server. The `unit-php` variant supports PHP >= 7.4.
 
 Explore all available tags on our [Docker Hub](https://hub.docker.com/r/shinsenter/php/tags).

--- a/build/config.sh
+++ b/build/config.sh
@@ -142,7 +142,6 @@ with-unit)
     ;;
 with-f8p)
     verlt "$PHP_VERSION" "8.2" && SKIP_BUILD=1
-    verlte "8.4" "$PHP_VERSION" && SKIP_BUILD=1
     PREFIX="frankenphp"
     BUILD_NAME="$DEFAULT_REPO/frankenphp"
     BUILD_SOURCE_IMAGE="dunglas/frankenphp:1-php$PHP_VERSION$SUFFIX"


### PR DESCRIPTION
This reverts commit 1402624128c36259365bca6a48799763750b0867.
Since [the official Docker images for PHP 8.4](https://github.com/dunglas/frankenphp/pull/1183) are published.