### PR TITLE
[5.x] Add PHP 8.4 for Hyperf docker images

### DIFF
--- a/build/config.sh
+++ b/build/config.sh
@@ -213,8 +213,7 @@ app-*)
         LATEST_PHP="8.3"
         BUILD_PLATFORM="linux/amd64,linux/arm/v7,linux/arm64/v8"
         BUILD_FROM_IMAGE="$DEFAULT_REPO/phpfpm-nginx"
-        verlt "$PHP_VERSION" "7.2"  && SKIP_BUILD=1
-        verlte "8.4" "$PHP_VERSION" && SKIP_BUILD=1
+        verlt "$PHP_VERSION" "7.2" && SKIP_BUILD=1
         if verlte "8.3" "$PHP_VERSION"; then
             BUILD_PLATFORM="linux/amd64,linux/arm64/v8"
         fi


### PR DESCRIPTION
Swoole currently support PHP 8.4