### PR TITLE
fix: support s6-overlay 3.2.3.1 user bundle layout

### DIFF
--- a/src/php/common/rootfs/usr/local/utils/s6-service
+++ b/src/php/common/rootfs/usr/local/utils/s6-service
@@ -9,6 +9,10 @@
 # service dirs
 s6="/etc/s6-overlay/s6-rc.d"
 disabled_s6="/etc/s6-overlay/s6-rc.d.disabled"
+user_bundle="${s6}/user"
+
+# s6-overlay 3.2.3.1 moved user bundle definitions outside s6-rc.d.
+[ -d "/etc/s6-overlay/user-bundles.d/user" ] && user_bundle="/etc/s6-overlay/user-bundles.d/user"
 
 # show help if no args or help flag
 case "$1" in
@@ -49,7 +53,7 @@ create() {
 hook_name="s6-exit-$(printf '%s' "$name" | tr -d '~')"
 svc_path="${s6}/${name}"
 deps_path="${s6}/${name}/dependencies.d"
-flag_path="${s6}/user/contents.d/${name}"
+flag_path="${user_bundle}/contents.d/${name}"
 
 # load file content if param is a file
 [ -n "$1" ] && [ -f "$1" ] && set -- "$(cat "$1")"


### PR DESCRIPTION
## Summary

- Use `/etc/s6-overlay/user-bundles.d/user` for user bundle membership flags when the directory is available.
- Keep `/etc/s6-overlay/s6-rc.d/user` as a fallback for s6-overlay 3.2.3.0 and older layouts.
- Prevent `s6-service` from recreating the deprecated `s6-rc.d/user` directory on current images.

## Root cause

s6-overlay 3.2.3.1 moved the `user` and `user2` bundle definitions from `s6-rc.d` to `user-bundles.d`. Individual service definitions still belong in `s6-rc.d`.

The `s6-service` helper continued writing service membership flags to `s6-rc.d/user/contents.d`. Creating that legacy `user` directory makes s6-overlay disable scanning of `user-bundles.d`, then compilation fails because the recreated directory is not a complete bundle definition:

```text
s6-rc-compile: fatal: unable to read /etc/s6-overlay/s6-rc.d/user/type: No such file or directory
```

The directory-based selection in this patch supports both layouts without version parsing.

## Verification

- Reproduced the startup failure with `shinsenter/php:8.3-fpm-nginx@sha256:ee34b4045dea30558c5bf4e53067de1d3c55e7f6b771236b1119124e4aaf01ec`.
- Verified POSIX shell and Bash syntax.
- Verified service creation still writes to the legacy bundle with the previous 3.2.3.0 image digest.
- Verified create, disable, and enable operations use `user-bundles.d` with 3.2.3.1 and do not recreate `s6-rc.d/user`.
- Successfully compiled the resulting 3.2.3.1 s6-rc database.
- Successfully booted the affected PHP image with the corrected filesystem for both `ENABLE_CRONTAB=0` and `ENABLE_CRONTAB=1`.

Closes #423.
Closes #424.
